### PR TITLE
Update README.md on how to use commit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The basic workflow for adding features in should be something like this:
 ## Committing Procedure
 Before making any changes to ORCA, please review [STYLEGUIDE.md](STYLEGUIDE.md).
 
-To utilize the the commit template as shown in the [.gitmessage](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/.gitmessage) file, run `git config commit.template "C:/Users/YOUR_NAME/uhd_radar/.gitmessage"` and edit the portion in quotes to where ever the .gitmessage file is stored. Now after you stage your changes, run `git commit` and the template will open. If you are using VSCode, a new tab with the template will open which you can edit before hitting the blue commit button. Finally you can push your changes. More information on the commit style guide can be found at [COMMITSTYLEGUIDE.md](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/COMMITSTYLEGUIDE.md).
+To utilize the commit template as shown in the [.gitmessage](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/.gitmessage) file, run `git config commit.template "C:/Users/YOUR_NAME/uhd_radar/.gitmessage"` and edit the portion in quotes to wherever the .gitmessage file is stored. Now after you stage your changes, run `git commit` and the template will open. If you are using VSCode, a new tab with the template will open which you can edit before hitting the blue commit button. Finally you can push your changes. More information on the commit style guide can be found at [COMMITSTYLEGUIDE.md](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/COMMITSTYLEGUIDE.md).
 
 Please follow the commit and pull request templates, which will auto-populate whenever requesting to perform either action. 
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ The basic workflow for adding features in should be something like this:
 5. Go to GitHub and you'll be prompted to create a [pull request](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). Pull requests are a GitHub feature that lets you and others preview what happens if you merge your branch into the `main` branch. You can send others a link so we can all review the changes you're propsoing, including making comments on them and discussing if there are any issues.
 
 ## Committing Procedure
-Before making any changes to ORCA, please review [STYLEGUIDE.md](STYLEGUIDE.md) Additionally, please follow the commit and pull request templates, which will auto-populate whenever requesting to perform either action. 
+Before making any changes to ORCA, please review [STYLEGUIDE.md](STYLEGUIDE.md).
+
+To utilize the the commit template as shown in the [.gitmessage](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/.gitmessage) file, run `git config commit.template "C:/Users/YOUR_NAME/uhd_radar/.gitmessage"` and edit the portion in quotes to where ever the .gitmessage file is stored. Now after you stage your changes, run `git commit` and the template will open. If you are using VSCode, a new tab with the template will open which you can edit before hitting the blue commit button. Finally you can push your changes. More information on the commit style guide can be found at [COMMITSTYLEGUIDE.md](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/COMMITSTYLEGUIDE.md).
+
+Please follow the commit and pull request templates, which will auto-populate whenever requesting to perform either action. 
 
 ## Miscellaneous Notes
 ### Symbol Errors when Compiling 


### PR DESCRIPTION
The .gitmessage is the commit template. Also linked the COMMITSTYLEGUIDE.md to the README.md in the same section under Committing Procedure. 

Also there's no pull request template here, I deleted it because this isn't really a code change.