### PR TITLE
GPS Code Fixes

### DIFF
--- a/sdr/main.cpp
+++ b/sdr/main.cpp
@@ -412,36 +412,41 @@ int UHD_SAFE_MAIN(int argc, char *argv[]) {
   rx_metadata_t rx_md; // Captures metadata from rx_stream->recv() -- specifically primarily timeouts and other errors
 
   float inversion_phase; // Store phase to use for phase inversion of this chirp
-
-  //section 1 start because it breaks it IDK WHY IT BREAKS IT. it makes it so it cant find /data/rx_samps.bin
-  //and idk how because sjkdfkjsdflkjfslkj
   
   //Creating GPS log & vars
-  // printf("Starting GPS code...\n");
-  // using namespace boost::asio;
+  printf("Starting GPS code...\n");
+  using namespace boost::asio;
 
-  // io_service io;
-  // serial_port serial(io);
+  io_service io;
+  serial_port serial(io);
+  bool using_gps = true;
 
-  // printf("Opening serial port...\n");
-  // serial.open("/dev/ttyACM0");  // Adjust if needed for your system
-  // printf("Serial port opened.\n");
-  // serial.set_option(serial_port_base::baud_rate(115200));
-  // serial.set_option(serial_port_base::character_size(8));
-  // serial.set_option(serial_port_base::parity(serial_port_base::parity::none));
-  // serial.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
-  // serial.set_option(serial_port_base::flow_control(serial_port_base::flow_control::none));
+  // TODO: Consider using a library for working with GPS;
+  try {
+    printf("Opening serial port...\n");
+    serial.open("/dev/ttyACM0");  // Adjust if needed for your system
+  } catch (boost::system::system_error err) {
+    printf("Failed to open GPS.\n");
+    using_gps = false;
+  }
 
-  // // Send UBX commands to configure GPS
-  // configureRate(serial, 3);              // 3 Hz update rate
-  // configureNMEAMessages(serial, 1);      // Enable only GGA
+  if (using_gps) {
+    printf("Serial port opened.\n");
+    serial.set_option(serial_port_base::baud_rate(115200));
+    serial.set_option(serial_port_base::character_size(8));
+    serial.set_option(serial_port_base::parity(serial_port_base::parity::none));
+    serial.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
+    serial.set_option(serial_port_base::flow_control(serial_port_base::flow_control::none));
+    
+    // Send UBX commands to configure GPS
+    configureRate(serial, 3);              // 3 Hz update rate
+    configureNMEAMessages(serial, 1);      // Enable only GGA
+  }
 
-  // ofstream gps_output("gps_log.txt");
+  ofstream gps_output("gps_log.txt");
 
-  // std::string line;
-  // char c; 
-
-  //section 1 end
+  std::string line;
+  char c; 
 
   // Note: This print statement is used by automated post-processing code. Please be careful about changing the format.
   cout << "[START] Beginning main loop" << endl;
@@ -455,11 +460,9 @@ int UHD_SAFE_MAIN(int argc, char *argv[]) {
     // Check if we have a full sample_sum ready to write to file
     if (!checkForFullSampleSum(chirp, sample_sum, outfile)) {exit(1);};
 
-//TODO: if this code below is not commented, then the chirp won't work and go to the spec 
-// analyzer so it needs to be edited
-/*
-// Our GPS method (below commented GPS from old version)
-    if (((pulses_received % 2000) == 0) && (sdr.getClkRef() == "gpsdo")) {
+
+    // Our GPS method (below commented GPS from old version)
+    if (using_gps && ((pulses_received % 2000) == 0) && (sdr.getClkRef() == "gpsdo")) {
       read(serial, buffer(&c, 1));
       if (c == '\n') {
           if (line.find("$GNGGA") == 0) {
@@ -510,8 +513,6 @@ int UHD_SAFE_MAIN(int argc, char *argv[]) {
           line += c;
       }
     }
-      */
-
 
 
     // get gps data


### PR DESCRIPTION
ORCA assumes that some USB/UART-like device is connected to the raspberry pi for GPS stuff. This requires a user to 1. have a GPS device connected, and occasionally 2. set "/dev/ttyACM0" to a valid port as per the connected device. This causes the code to fail on noGPS systems. My workaround is to have a try-catch for GSP, which continues the code's compatibility with older Peregrine/Frightful/Flightless UAVs while allowing operation on noGPS systems.

# Executive Summary
GPS Code Fixes

## Type of change
- [✅] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code maintenence/cleaning

# Functionality Tests
## Instruction
Tested on RPi 4B and RPi 5 hardware Roble field tests.

## Test Description
Type of test (select all that apply)
- [✅] Hardware
- [❓] Software 

# Checklist:

- [✅] My code follows the style guidelines of this project ([Style Guide Link](https://github.com/HI-SNR-Lab/uhd_radar/blob/main/STYLEGUIDE.md))
- [N/A] If new functions have been added, unit tests have been made for it
- [✅] I have performed a self-review of my code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A (no change needed)] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information
Fixes issue #: Idk

Additional dependencies: 
None